### PR TITLE
Remove global gradient opacity override

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -136,6 +136,6 @@ html[dir="rtl"] .pagination-container {
 }
 
 
-.bg-gradient-to-br{
+/* .bg-gradient-to-br{
   opacity: 0.3 !important;
-}
+} */


### PR DESCRIPTION
- Comment out bg-gradient-to-br opacity rule in globals.css
- Allow gradients to display with their natural opacity
- Maintain specific loader opacity control through loading.scss